### PR TITLE
feat: add macOS & Windows code signing and notarization support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,12 +114,24 @@ jobs:
         run: npm run electron:build:mac -- --x64 --arm64
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
       - name: Build Electron (Windows)
         if: matrix.platform == 'win'
         run: npm run electron:build:win -- --x64 --arm64
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
       - name: Build Electron (Linux)
         if: matrix.platform == 'linux'

--- a/electron/entitlements.mac.inherit.plist
+++ b/electron/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/electron/entitlements.mac.plist
+++ b/electron/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.3.8",
+				"@electron/notarize": "^3.1.1",
 				"@inlang/cli": "^3.0.12",
 				"@inlang/paraglide-js": "2.6.0",
 				"@inlang/plugin-m-function-matcher": "^2.1.0",
@@ -520,34 +521,17 @@
 			}
 		},
 		"node_modules/@electron/notarize": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
-			"integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-3.1.1.tgz",
+			"integrity": "sha512-uQQSlOiJnqRkTL1wlEBAxe90nVN/Fc/hEmk0bqpKk8nKjV1if/tXLHKUPePtv9Xsx90PtZU8aidx5lAiOpjkQQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.1.1",
-				"fs-extra": "^9.0.1",
+				"debug": "^4.4.0",
 				"promise-retry": "^2.0.1"
 			},
 			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/@electron/notarize/node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
+				"node": ">= 22.12.0"
 			}
 		},
 		"node_modules/@electron/osx-sign": {
@@ -4143,6 +4127,37 @@
 				"electron-builder-squirrel-windows": "26.0.12"
 			}
 		},
+		"node_modules/app-builder-lib/node_modules/@electron/notarize": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+			"integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"fs-extra": "^9.0.1",
+				"promise-retry": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/notarize/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/app-builder-lib/node_modules/fs-extra": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -5526,6 +5541,7 @@
 			"integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"app-builder-lib": "26.0.12",
 				"builder-util": "26.0.11",
@@ -13260,21 +13276,6 @@
 				"picomatch": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/svelte-check/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/tagged-tag": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.8",
+		"@electron/notarize": "^3.1.1",
 		"@inlang/cli": "^3.0.12",
 		"@inlang/paraglide-js": "2.6.0",
 		"@inlang/plugin-m-function-matcher": "^2.1.0",
@@ -73,6 +74,7 @@
 		"appId": "com.whatsapp.backup-reader",
 		"productName": "WhatsApp Backup Reader",
 		"afterPack": "./scripts/afterPack.cjs",
+		"afterSign": "./scripts/notarize.cjs",
 		"publish": {
 			"provider": "github",
 			"owner": "rodrigogs",
@@ -109,6 +111,10 @@
 		],
 		"mac": {
 			"category": "public.app-category.utilities",
+			"hardenedRuntime": true,
+			"gatekeeperAssess": false,
+			"entitlements": "electron/entitlements.mac.plist",
+			"entitlementsInherit": "electron/entitlements.mac.inherit.plist",
 			"icon": "static/icon.icns",
 			"target": [
 				{

--- a/scripts/notarize.cjs
+++ b/scripts/notarize.cjs
@@ -1,0 +1,57 @@
+/**
+ * electron-builder afterSign hook
+ * Notarizes the macOS app bundle to reduce Gatekeeper warnings.
+ *
+ * This is intentionally a no-op unless notarization credentials are present.
+ */
+
+const path = require('node:path');
+
+let notarize;
+try {
+	({ notarize } = require('@electron/notarize'));
+} catch {
+	notarize = null;
+}
+
+module.exports = async function notarizeAfterSign(context) {
+	if (context.electronPlatformName !== 'darwin') return;
+	if (!notarize) {
+		console.log('[afterSign] @electron/notarize not installed; skipping notarization');
+		return;
+	}
+
+	const appName = context.packager.appInfo.productFilename;
+	const appPath = path.join(context.appOutDir, `${appName}.app`);
+
+	const hasAppleIdFlow = Boolean(process.env.APPLE_ID && process.env.APPLE_APP_SPECIFIC_PASSWORD);
+	const hasApiKeyFlow = Boolean(process.env.APPLE_API_KEY && process.env.APPLE_API_KEY_ID && process.env.APPLE_API_ISSUER);
+
+	if (!hasAppleIdFlow && !hasApiKeyFlow) {
+		console.log('[afterSign] No notarization credentials provided; skipping notarization');
+		return;
+	}
+
+	console.log(`[afterSign] Notarizing ${appPath}...`);
+
+	// Prefer API key flow when available.
+	if (hasApiKeyFlow) {
+		await notarize({
+			appPath,
+			appleApiKey: process.env.APPLE_API_KEY,
+			appleApiKeyId: process.env.APPLE_API_KEY_ID,
+			appleApiIssuer: process.env.APPLE_API_ISSUER
+		});
+		console.log('[afterSign] Notarization complete (API key)');
+		return;
+	}
+
+	// Apple ID flow (requires APPLE_TEAM_ID for some setups)
+	await notarize({
+		appPath,
+		appleId: process.env.APPLE_ID,
+		appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
+		teamId: process.env.APPLE_TEAM_ID
+	});
+	console.log('[afterSign] Notarization complete (Apple ID)');
+};


### PR DESCRIPTION
## Summary
Adds optional code signing and notarization support for macOS and Windows builds.

## Changes
- **macOS**: Hardened runtime + entitlements + `afterSign` hook for Apple notarization
- **Windows**: Supports Authenticode signing via `WIN_CSC_LINK`/`WIN_CSC_KEY_PASSWORD` (or `CSC_*` fallback)
- **Graceful degradation**: Builds still succeed without secrets (unsigned)

## Required Secrets (GitHub Actions repository secrets)

### macOS Signing
| Secret | Description |
|--------|-------------|
| `CSC_LINK` | Base64-encoded `.p12` (Developer ID Application certificate) |
| `CSC_KEY_PASSWORD` | Password for the `.p12` |

### macOS Notarization (recommended for CI: API Key)
**Option B - App Store Connect API Key (recommended):**
| Secret | Description |
|--------|-------------|
| `APPLE_API_KEY` | `.p8` key contents |
| `APPLE_API_KEY_ID` | Key ID |
| `APPLE_API_ISSUER` | Issuer ID |

**Option A - Apple ID (works, but less ideal for CI):**
| Secret | Description |
|--------|-------------|
| `APPLE_ID` | Apple Developer account email |
| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password |
| `APPLE_TEAM_ID` | 10-char team ID |

### Windows Signing
| Secret | Description |
|--------|-------------|
| `WIN_CSC_LINK` | Base64-encoded `.pfx`/`.p12` Windows code-signing certificate |
| `WIN_CSC_KEY_PASSWORD` | Password for the certificate |

## Safe `gh` CLI setup commands
These avoid echoing secrets into your terminal output:

```bash
# macOS signing cert (.p12)
base64 -i path/to/macos-dev-id.p12 | gh secret set CSC_LINK -R rodrigogs/whats-reader --body-file -
printf '%s' 'YOUR_P12_PASSWORD' | gh secret set CSC_KEY_PASSWORD -R rodrigogs/whats-reader --body-file -

# macOS notarization (API key)
gh secret set APPLE_API_KEY -R rodrigogs/whats-reader --body-file path/to/AuthKey_XXXXXX.p8
printf '%s' 'KEY_ID' | gh secret set APPLE_API_KEY_ID -R rodrigogs/whats-reader --body-file -
printf '%s' 'ISSUER_ID' | gh secret set APPLE_API_ISSUER -R rodrigogs/whats-reader --body-file -

# Windows signing cert (.pfx)
base64 -i path/to/windows-cert.pfx | gh secret set WIN_CSC_LINK -R rodrigogs/whats-reader --body-file -
printf '%s' 'YOUR_PFX_PASSWORD' | gh secret set WIN_CSC_KEY_PASSWORD -R rodrigogs/whats-reader --body-file -
```

## Notes
- Even signed Windows builds may still trigger SmartScreen until reputation builds up (EV certs help).
- macOS requires notarization to avoid Gatekeeper warnings for most users.
