### PR TITLE
fix(chat): prevent scrollHeight errors with null checks

### DIFF
--- a/src/lib/components/ChatView.svelte
+++ b/src/lib/components/ChatView.svelte
@@ -264,7 +264,7 @@ function setupIntersectionObserver() {
 }
 
 function loadMoreMessages() {
-	if (isLoadingMore || !renderedItems.hasMore) return;
+	if (isLoadingMore || !renderedItems.hasMore || !chatContainer) return;
 
 	isLoadingMore = true;
 
@@ -305,8 +305,10 @@ $effect(() => {
 $effect(() => {
 	if (messages.length > 0 && chatContainer && !hasScrolledToBottom) {
 		requestAnimationFrame(() => {
-			chatContainer.scrollTop = chatContainer.scrollHeight;
-			hasScrolledToBottom = true;
+			if (chatContainer) {
+				chatContainer.scrollTop = chatContainer.scrollHeight;
+				hasScrolledToBottom = true;
+			}
 		});
 	}
 });


### PR DESCRIPTION
## Summary

Fixes runtime error: `Cannot read properties of null (reading 'scrollHeight')`

## Bug Details

The error occurred when the chat container element was accessed after being unmounted or when it became null between an effect check and a callback execution.

## Changes

- Added null check inside `requestAnimationFrame` callback in scroll-to-bottom effect
- Prevents crashes when component unmounts during scroll operations

## Testing

- Verified no TypeScript/Svelte errors
- Prevents the scrollHeight null reference error

**Type**: Bug fix (patch release)