### PR TITLE
chore: auto-sync dev with main after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Sync dev with main
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin dev
+          git checkout dev
+          git merge origin/main --no-edit -m "chore: sync dev with main after release"
+          git push origin dev
+
       - name: Trigger Build Workflow
         if: steps.semantic.outputs.new_release_published == 'true'
         uses: actions/github-script@v7


### PR DESCRIPTION
Adds automatic synchronization of dev branch with main after semantic-release creates a new version.

This ensures both branches stay in sync without manual intervention.